### PR TITLE
Add theme toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The website is optimized for performance with:
 - Compressed assets
 - Responsive images
 - Modern JavaScript features
+- Light/dark theme toggle
 
 ### Customization
 

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,10 +1,14 @@
 import { Toaster } from "./ui/toaster"
 import { ThemeProvider } from "./theme-provider"
+import { ThemeToggle } from "./ThemeToggle"
 
 export function Layout({ children }) {
   return (
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
       <div className="min-h-screen bg-background font-sans antialiased">
+        <header className="container mx-auto px-4 py-4 flex justify-end">
+          <ThemeToggle />
+        </header>
         <main className="container mx-auto px-4 py-8">
           {children}
         </main>

--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -1,0 +1,31 @@
+import { useTheme } from 'next-themes'
+import { useEffect, useState } from 'react'
+import { Sun, Moon } from 'lucide-react'
+
+import { Button } from './ui/button'
+
+export function ThemeToggle() {
+  const { theme = 'light', setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  if (!mounted) {
+    return null
+  }
+
+  const isLight = theme === 'light'
+
+  return (
+    <Button
+      variant="outline"
+      size="icon"
+      aria-label="Toggle theme"
+      onClick={() => setTheme(isLight ? 'dark' : 'light')}
+    >
+      {isLight ? <Moon className="size-4" /> : <Sun className="size-4" />}
+    </Button>
+  )
+}


### PR DESCRIPTION
## Summary
- add a ThemeToggle component for switching between light and dark themes
- render ThemeToggle in the layout header
- mention the new theme toggle in the README

## Testing
- `npm run lint` *(fails: 'index' is defined but never used and other existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877e2a99de48327851766a413e67859